### PR TITLE
Added: automake, pkgconf, libtool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Index
+
+## Installation Kivy and Buildozer on Ubuntu 18.04 based distros
+
+The install-kivy-buildozer-dependencies.sh contains the complete list of the Buildozer dependencies. So the easiest way to install Buildozer is to use the install-kivy-buildozer-dependencies.sh.
+
+1. Download the **install-kivy-buildozer-dependencies.sh** any way you like. E.g.
+
+    ```curl -LJ0 https://raw.githubusercontent.com/HeaTTheatR/KivyMD-data/master/install-kivy-buildozer-dependencies.sh
+```
+
+2. Add execution permissions:
+
+    ```chmod +x install-kivy-buildozer-dependencies.sh```
+
+3. Run the script:
+
+    ```./install-kivy-buildozer-dependencies.sh```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The install-kivy-buildozer-dependencies.sh contains the complete list of the Bui
 
 1. Download the **install-kivy-buildozer-dependencies.sh** any way you like. E.g.
 
-    ```curl -LJ0 https://raw.githubusercontent.com/HeaTTheatR/KivyMD-data/master/install-kivy-buildozer-dependencies.sh```
+    ```curl -LJO https://raw.githubusercontent.com/HeaTTheatR/KivyMD-data/master/install-kivy-buildozer-dependencies.sh```
 
 2. Add execution permissions:
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The install-kivy-buildozer-dependencies.sh contains the complete list of the Bui
 
 1. Download the **install-kivy-buildozer-dependencies.sh** any way you like. E.g.
 
-    ```curl -LJ0 https://raw.githubusercontent.com/HeaTTheatR/KivyMD-data/master/install-kivy-buildozer-dependencies.sh
-```
+    ```curl -LJ0 https://raw.githubusercontent.com/HeaTTheatR/KivyMD-data/master/install-kivy-buildozer-dependencies.sh```
 
 2. Add execution permissions:
 

--- a/install-kivy-buildozer-dependencies.sh
+++ b/install-kivy-buildozer-dependencies.sh
@@ -51,8 +51,11 @@ sudo apt install -y \
     libltdl-dev \
     libffi-dev \
     libssl-dev \
+    automake \
     autoconf \
-    autotools-dev
+    autotools-dev \
+    pkgconf \
+    libtool \
     cmake
 
 # Install Buildozer

--- a/install-kivy-buildozer-dependencies.sh
+++ b/install-kivy-buildozer-dependencies.sh
@@ -56,6 +56,9 @@ sudo apt install -y \
     cmake
 
 # Install Buildozer
+mkdir ~/buildozer-repo
+cd ~/buildozer-repo
+
 git clone https://github.com/kivy/buildozer.git
 cd buildozer
 sudo python3 setup.py install


### PR DESCRIPTION
On Linux Mint 19.3 (based on Ubuntu 18.04) building *.apk failed.
Completed successfully after automake, pkgconf, libtool was installed